### PR TITLE
Fixing typo and return values in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ http://go-geoindex.appspot.com/static/cluster.html - A map with 100K points arou
     }
 
     // Implement Point interface
-    func (d *Driver) Lat() { return d.lat }
-    func (d *Driver) Lon() { return d.lat }
-    func (d *Driver) Id() { return d.id }
+    func (d *Driver) Lat() float64 { return d.lat }
+    func (d *Driver) Lon() float64 { return d.lon }
+    func (d *Driver) Id() string { return d.id }
 
     // create points index with resolution (cell size) 0.5 km
     index := NewPointsIndex(Km(0.5))

--- a/point.go
+++ b/point.go
@@ -42,14 +42,55 @@ func (p *GeoPoint) Lon() float64 {
 	return p.Plon
 }
 
+func Direction(p1, p2 Point) string {
+
+	bearingList := []string{"NE", "E", "SE", "S", "SW", "W", "NW", "N"}
+
+	bearing := Bearing(p1, p2)
+
+	index := bearing - 22.5
+
+	if index < 0 {
+		index += 360
+	}
+	indexInt := int(index / 45.0)
+
+	return bearingList[indexInt]
+}
+
+func Bearing(p1, p2 Point) float64 {
+
+	// lamda LON
+	// phi   LAT
+
+	lat1 := toRadians(p1.Lat())
+	lon1 := toRadians(p1.Lon())
+
+	lat2 := toRadians(p2.Lat())
+	lon2 := toRadians(p2.Lon())
+
+	y := math.Sin(lon2-lon1) * math.Cos(lat2)
+	x := math.Cos(lat1)*math.Sin(lat2) -
+		math.Sin(lat1)*math.Cos(lat2)*math.Cos(lon2-lon1)
+
+	bearing := math.Atan2(y, x)
+
+	return float64(int(toDegrees(bearing) + 180%360))
+}
+
 func Distance(p1, p2 Point) Meters {
 	return distance(p1, p2)
 }
 
+func toDegrees(x float64) float64 {
+	return x * 180.0 / math.Pi
+}
+
+func toRadians(x float64) float64 {
+	return x * math.Pi / 180.0
+}
+
 func distance(p1, p2 Point) Meters {
-	toRadians := func(x float64) float64 {
-		return x * math.Pi / 180.0
-	}
 
 	dLat := toRadians(p2.Lat() - p1.Lat())
 	dLng := toRadians(p2.Lon() - p1.Lon())

--- a/points-index.go
+++ b/points-index.go
@@ -181,3 +181,28 @@ func (points *PointsIndex) KNearest(point Point, k int, maxDistance Meters, acce
 
 	return sortedPoints.points[0:k]
 }
+
+// PointsWithin returns all points with distance of point that match the accept criteria.
+func (points *PointsIndex) PointsWithin(point Point, distance Meters, accept func(p Point) bool) []Point {
+
+	d := int(distance / points.index.resolution)
+
+	if d == 0 {
+		d = 1
+	}
+
+	idx := cellOf(point, points.index.resolution)
+
+	nearbyPoints := make([]Point, 0)
+	nearbyPoints = getPointsAppend(nearbyPoints, points.index.get(idx.x-d, idx.x+d, idx.y-d, idx.y+d), accept)
+
+	// filter points which longer than maxDistance away from point.
+	withinPoints := make([]Point, 0)
+	for _, nearbyPoint := range nearbyPoints {
+		if Distance(point, nearbyPoint) < distance {
+			withinPoints = append(withinPoints, nearbyPoint)
+		}
+	}
+
+	return withinPoints
+}


### PR DESCRIPTION
The example in the README.md file had a copy and past error with lat
being used in the Driver Lon method. Also the Lat(), Lon(), and Id()
methods were all missing return types.