### PR TITLE
Improved performance + added Clone

### DIFF
--- a/clustering-index.go
+++ b/clustering-index.go
@@ -33,6 +33,16 @@ func NewExpiringClusteringIndex(expiration Minutes) *ClusteringIndex {
 	return index
 }
 
+func (index *ClusteringIndex) Clone() *ClusteringIndex {
+	clone := &ClusteringIndex{}
+
+	clone.streetLevel = index.streetLevel.Clone()
+	clone.cityLevel = index.cityLevel.Clone()
+	clone.worldLevel = index.worldLevel.Clone()
+
+	return clone
+}
+
 // Add adds a point.
 func (index *ClusteringIndex) Add(point Point) {
 	index.streetLevel.Add(point)

--- a/count-index.go
+++ b/count-index.go
@@ -36,6 +36,21 @@ func NewExpiringCountIndex(resolution Meters, expiration Minutes) *CountIndex {
 	return &CountIndex{newGeoIndex(resolution, newExpiringCounter), make(map[string]Point)}
 }
 
+func (index *CountIndex) Clone() *CountIndex {
+	clone := &CountIndex{}
+
+	// Copy all entries from current positions
+	clone.currentPosition = make(map[string]Point, len(index.currentPosition))
+	for k, v := range index.currentPosition {
+		clone.currentPosition[k] = v
+	}
+
+	// Copying underlying geoindex data
+	clone.index = index.index.Clone()
+
+	return clone
+}
+
 // Add adds a point.
 func (countIndex *CountIndex) Add(point Point) {
 	countIndex.Remove(point.Id())

--- a/geo-index.go
+++ b/geo-index.go
@@ -40,6 +40,23 @@ func newGeoIndex(resolution Meters, newEntry func() interface{}) *geoIndex {
 	return &geoIndex{resolution, make(map[cell]interface{}), newEntry}
 }
 
+func (i *geoIndex) Clone() *geoIndex {
+	clone := &geoIndex{
+		resolution: i.resolution,
+		index:      make(map[cell]interface{}, len(i.index)),
+		newEntry:   i.newEntry,
+	}
+	for k, v := range i.index {
+		set, ok := v.(set)
+		if !ok {
+			panic("Cannot cast value to set")
+		}
+		clone.index[k] = set.Clone()
+	}
+
+	return clone
+}
+
 // AddEntryAt adds an entry if missing, returns the entry at specific position.
 func (geoIndex *geoIndex) AddEntryAt(point Point) interface{} {
 	square := cellOf(point, geoIndex.resolution)
@@ -72,7 +89,7 @@ func (geoIndex *geoIndex) Range(topLeft Point, bottomRight Point) []interface{} 
 }
 
 func (geoIndex *geoIndex) get(minx int, maxx int, miny int, maxy int) []interface{} {
-	entries := make([]interface{}, 0, 0)
+	entries := make([]interface{}, 0)
 
 	for x := minx; x <= maxx; x++ {
 		for y := miny; y <= maxy; y++ {
@@ -83,16 +100,4 @@ func (geoIndex *geoIndex) get(minx int, maxx int, miny int, maxy int) []interfac
 	}
 
 	return entries
-}
-
-func (g *geoIndex) getCells(minx int, maxx int, miny int, maxy int) []cell {
-	indices := make([]cell, 0)
-
-	for x := minx; x <= maxx; x++ {
-		for y := miny; y <= maxy; y++ {
-			indices = append(indices, cell{x, y})
-		}
-	}
-
-	return indices
 }

--- a/sets_test.go
+++ b/sets_test.go
@@ -1,37 +1,35 @@
 package geoindex
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSet(t *testing.T) {
 	set := newSet()
 	assert.Equal(t, set.Size(), 0)
 
-	set.Add(charring.Id(), charring)
+	set.Add(charring.Id())
 	assert.Equal(t, set.Size(), 1)
 
-	set.Add(embankment.Id(), embankment)
+	set.Add(embankment.Id())
 	assert.Equal(t, set.Size(), 2)
 
 	set.Remove(charring.Id())
 	assert.Equal(t, set.Size(), 1)
 
-	value, ok := set.Get(charring.Id())
+	ok := set.Has(charring.Id())
 	assert.False(t, ok)
-	assert.Nil(t, value)
 
-	value, ok = set.Get(embankment.Id())
+	ok = set.Has(embankment.Id())
 	assert.True(t, ok)
-	assert.NotNil(t, value)
-	assert.Equal(t, value.(Point).Id(), "Embankment")
 
-	set.Add(picadilly.Id(), picadilly)
-	set.Add(oxford.Id(), oxford)
+	set.Add(picadilly.Id())
+	set.Add(oxford.Id())
 
-	assert.True(t, pointsEqualIgnoreOrder(toPoints(set.Values()), []Point{picadilly, embankment, oxford}))
+	assert.Equal(t, set.Size(), 3)
 }
 
 func toPoints(values []interface{}) []Point {
@@ -48,12 +46,12 @@ func TestExpiringSet(t *testing.T) {
 	currentTime := time.Now()
 
 	now = currentTime
-	set.Add(picadilly.Id(), picadilly)
+	set.Add(picadilly.Id())
 
 	now = currentTime.Add(5 * time.Minute)
-	set.Add(oxford.Id(), oxford)
+	set.Add(oxford.Id())
 	assert.Equal(t, set.Size(), 2)
-	assert.Equal(t, len(set.Values()), 2)
+	assert.Equal(t, len(set.IDs()), 2)
 
 	set.Remove(picadilly.Id())
 	assert.Equal(t, set.Size(), 1)
@@ -61,25 +59,25 @@ func TestExpiringSet(t *testing.T) {
 	now = currentTime.Add(11 * time.Minute)
 	assert.Equal(t, set.Size(), 1)
 
-	set.Add(oxford.Id(), oxford)
+	set.Add(oxford.Id())
 	assert.Equal(t, set.Size(), 1)
-	assert.Equal(t, len(set.Values()), 1)
+	assert.Equal(t, len(set.IDs()), 1)
 
 	now = currentTime.Add(16 * time.Minute)
 	assert.Equal(t, set.Size(), 1)
-	assert.Equal(t, len(set.Values()), 1)
+	assert.Equal(t, len(set.IDs()), 1)
 
 	now = currentTime.Add(22 * time.Minute)
 	assert.Equal(t, set.Size(), 0)
-	assert.Equal(t, len(set.Values()), 0)
+	assert.Equal(t, len(set.IDs()), 0)
 
 	now = currentTime.Add(24 * time.Minute)
 	assert.Equal(t, set.Size(), 0)
-	set.Add(oxford.Id(), oxford)
+	set.Add(oxford.Id())
 	now = currentTime.Add(25 * time.Minute)
-	set.Add(oxford.Id(), oxford)
+	set.Add(oxford.Id())
 	now = currentTime.Add(26 * time.Minute)
-	set.Add(oxford.Id(), oxford)
+	set.Add(oxford.Id())
 	assert.Equal(t, set.Size(), 1)
 
 	set.Remove(oxford.Id())


### PR DESCRIPTION
Changed the underlying geoindex to not store the value being indexed and just store the ID instead, this reduces some of the memory overhead. This means that the `Set` interface has changed.

Also added is a `Clone` method to each index.